### PR TITLE
fix student_id assert and leave_nj env for github action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,4 +28,5 @@ jobs:
           FAM_MEM_HEALTH_CODE_COLOR: ${{ secrets.FAM_MEM_HEALTH_CODE_COLOR }}
           LAST_RNA: ${{ secrets.LAST_RNA }}
           TRY_N_TIMES: ${{ secrets.TRY_N_TIMES }}
+          LEAVE_NJ: ${{ secrets.LEAVE_NJ }}
         run: python decodeEnv.py && python checkin.py

--- a/decodeEnv.py
+++ b/decodeEnv.py
@@ -4,7 +4,7 @@ import json
 info = {}
 info['student_id'] = os.environ['STUDENT_ID']
 assert info['student_id'] != '', "Expected infomation `student_id` not found. Check repository secret"
-assert len(info['student_id']) == 9 or len(info['student_id']) == 12, "Expected infomation `student_id` is not 9 or 12 digits. Check repository secret"
+assert len(info['student_id']) == 9 or len(info['student_id']) == 10 or len(info['student_id']) == 12, "Expected infomation `student_id` is not 9, 10 or 12 digits. Check repository secret"
 
 info['password'] = os.environ['PASSWORD']
 assert info['password'] != '', "Expected infomation `password` not found. Check epository secret"


### PR DESCRIPTION
- the length of student id for postgraduate is 10 digits, starts with MF or MG.
- read leave_nj env from secrets for github action workflow.